### PR TITLE
expose ByteReader and ByteWriter to users

### DIFF
--- a/lib/dart_midi.dart
+++ b/lib/dart_midi.dart
@@ -6,3 +6,5 @@ export 'src/midi_header.dart';
 export 'src/midi_events.dart';
 export 'src/midi_file.dart';
 export 'src/midi_events.dart';
+export 'src/byte_reader.dart';
+export 'src/byte_writer.dart';


### PR DESCRIPTION
I'm using this library for my app at beatscratch.io/app (if you wanna see it) but mostly just want to use it to convert MIDI events to binary for sending through platform channels and JavaScript. This gets rid of a compiler warning for me :)